### PR TITLE
Add audius.comms() host function to QuickJS sandbox

### DIFF
--- a/src/api/AudiusClient.ts
+++ b/src/api/AudiusClient.ts
@@ -26,6 +26,11 @@ export class AudiusClient extends Context.Tag("AudiusClient")<
       path: string,
       options?: RequestOptions
     ) => Effect.Effect<unknown, Error>
+    readonly commsRequest: (
+      method: string,
+      path: string,
+      options?: RequestOptions
+    ) => Effect.Effect<unknown, Error>
   }
 >() {}
 
@@ -94,6 +99,9 @@ export const AudiusClientLive: Layer.Layer<AudiusClient, never, AppConfig> = Lay
         return json
       })
 
-    return { request }
+    const commsRequest = (_method: string, _path: string, _options?: RequestOptions): Effect.Effect<unknown, Error> =>
+      Effect.fail(new Error("Comms not implemented - see Unit 2A"))
+
+    return { request, commsRequest }
   })
 )

--- a/src/sandbox/Sandbox.ts
+++ b/src/sandbox/Sandbox.ts
@@ -98,48 +98,54 @@ export const SandboxLive: Layer.Layer<Sandbox, Error, AudiusClient | TypeGenerat
             logFn.dispose()
             consoleHandle.dispose()
 
-            // Inject audius.request using deferred promises.
+            // Helper: create a QuickJS host function that bridges to an
+            // Effect-based API client method via deferred promises.
             // Each call creates a QuickJSDeferredPromise, kicks off the
             // host-side API call, and returns the promise handle to the VM.
-            // When the API call resolves, we settle the deferred and pump
-            // executePendingJobs to advance the VM's promise chain.
+            const bridgeHostFn = (
+              name: string,
+              clientMethod: (method: string, path: string, options?: any) => Effect.Effect<unknown, Error>
+            ) => {
+              const fn = ctx.newFunction(name, (...args) => {
+                const method = ctx.dump(args[0]) as string
+                const path = ctx.dump(args[1]) as string
+                const options = args[2] ? ctx.dump(args[2]) as Record<string, unknown> : undefined
+
+                const deferred = ctx.newPromise()
+
+                const hostPromise = Effect.runPromise(
+                  clientMethod(method, path, options as any)
+                ).then(
+                  (result) => {
+                    const jsonStr = JSON.stringify(result)
+                    const strHandle = ctx.newString(jsonStr)
+                    deferred.resolve(strHandle)
+                    strHandle.dispose()
+                    ctx.runtime.executePendingJobs()
+                  },
+                  (e) => {
+                    const errorMsg = e instanceof Error ? e.message : String(e)
+                    const jsonStr = JSON.stringify({ error: errorMsg })
+                    const strHandle = ctx.newString(jsonStr)
+                    deferred.resolve(strHandle)
+                    strHandle.dispose()
+                    ctx.runtime.executePendingJobs()
+                  }
+                )
+
+                pendingPromises.push(hostPromise)
+
+                return deferred.handle
+              })
+              ctx.setProp(audiusHandle, name, fn)
+              fn.dispose()
+            }
+
             const audiusHandle = ctx.newObject()
-            const requestFn = ctx.newFunction("request", (...args) => {
-              const method = ctx.dump(args[0]) as string
-              const path = ctx.dump(args[1]) as string
-              const options = args[2] ? ctx.dump(args[2]) as Record<string, unknown> : undefined
+            bridgeHostFn("request", audiusClient.request)
+            bridgeHostFn("comms", audiusClient.commsRequest)
 
-              const deferred = ctx.newPromise()
-
-              // Kick off the host-side API call asynchronously
-              const hostPromise = Effect.runPromise(
-                audiusClient.request(method, path, options as any)
-              ).then(
-                (result) => {
-                  const jsonStr = JSON.stringify(result)
-                  const strHandle = ctx.newString(jsonStr)
-                  deferred.resolve(strHandle)
-                  strHandle.dispose()
-                  // Pump the VM event loop so the .then() handlers run
-                  ctx.runtime.executePendingJobs()
-                },
-                (e) => {
-                  const errorMsg = e instanceof Error ? e.message : String(e)
-                  const jsonStr = JSON.stringify({ error: errorMsg })
-                  const strHandle = ctx.newString(jsonStr)
-                  deferred.resolve(strHandle)
-                  strHandle.dispose()
-                  ctx.runtime.executePendingJobs()
-                }
-              )
-
-              pendingPromises.push(hostPromise)
-
-              return deferred.handle
-            })
-            ctx.setProp(audiusHandle, "request", requestFn)
             ctx.setProp(ctx.global, "audius", audiusHandle)
-            requestFn.dispose()
             audiusHandle.dispose()
 
             // Inject user code as a global string to avoid template literal injection
@@ -159,6 +165,12 @@ export const SandboxLive: Layer.Layer<Sandbox, Error, AudiusClient | TypeGenerat
               var _origRequest = audius.request;
               audius.request = function(method, path, options) {
                 return _origRequest(method, path, options)
+                  .then(function(jsonStr) { return JSON.parse(jsonStr); });
+              };
+
+              var _origComms = audius.comms;
+              audius.comms = function(method, path, options) {
+                return _origComms(method, path, options)
                   .then(function(jsonStr) { return JSON.parse(jsonStr); });
               };
 


### PR DESCRIPTION
## Summary
- Adds `audius.comms(method, path, options)` host function to the QuickJS WASM sandbox, bridging to `audiusClient.commsRequest()` for comms/messaging endpoints
- Extracts shared `bridgeHostFn` helper to eliminate duplication between `request` and `comms` host functions
- Adds `commsRequest` to the `AudiusClient` interface with a stub implementation (real implementation comes from Unit 2A)

## Test plan
- [x] TypeScript compilation passes (`pnpm build`)
- [x] `pnpm test` passes
- [ ] E2E testing deferred until merge with Unit 2A (which provides the real `commsRequest` implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)