### PR TITLE
Add commsRequest with x-sig signing for Audius comms endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@effect/platform": "^0.94.5",
     "@effect/platform-node": "^0.104.1",
     "@effect/rpc": "^0.73.0",
+    "@noble/curves": "^2.0.1",
+    "@noble/hashes": "^2.0.1",
     "effect": "^3.19.18",
     "quickjs-emscripten": "^0.31.0",
     "yaml": "^2.7.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@effect/rpc':
         specifier: ^0.73.0
         version: 0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
+      '@noble/curves':
+        specifier: ^2.0.1
+        version: 2.0.1
+      '@noble/hashes':
+        specifier: ^2.0.1
+        version: 2.0.1
       effect:
         specifier: ^3.19.18
         version: 3.19.19
@@ -146,6 +152,14 @@ packages:
     resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
     cpu: [x64]
     os: [win32]
+
+  '@noble/curves@2.0.1':
+    resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -437,6 +451,12 @@ snapshots:
 
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
+
+  '@noble/curves@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+
+  '@noble/hashes@2.0.1': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true

--- a/src/AppConfig.ts
+++ b/src/AppConfig.ts
@@ -9,6 +9,7 @@ import { Context, Effect, Layer } from "effect"
 
 export interface AppConfigShape {
   readonly apiKey: string
+  readonly apiSecret?: string
   readonly port: number
   readonly graphApiKey?: string
 }
@@ -24,7 +25,8 @@ export const AppConfigLive: Layer.Layer<AppConfig> = Layer.effect(
     const apiKey = process.env["AUDIUS_API_KEY"] ?? ""
     const portParsed = parseInt(process.env["PORT"] ?? "3000", 10)
     const port = Number.isFinite(portParsed) ? portParsed : 3000
+    const apiSecret = process.env["AUDIUS_API_SECRET"] || undefined
     const graphApiKey = process.env["GRAPH_API_KEY"] || undefined
-    return { apiKey, port, graphApiKey }
+    return { apiKey, apiSecret, port, graphApiKey }
   })
 )

--- a/src/api/AudiusClient.ts
+++ b/src/api/AudiusClient.ts
@@ -6,11 +6,18 @@
  * - Automatic x-api-key header injection
  * - JSON response parsing
  * - Effect-based error handling
+ *
+ * Also provides commsRequest() for the /comms/ messaging system
+ * which uses x-sig header authentication (secp256k1 + keccak256).
  */
 import { Context, Effect, Layer } from "effect"
+import { secp256k1 } from "@noble/curves/secp256k1.js"
+import { keccak_256 } from "@noble/hashes/sha3.js"
+import { hexToBytes } from "@noble/hashes/utils.js"
 import { AppConfig } from "../AppConfig.js"
 
 const BASE_URL = "https://api.audius.co/v1"
+const COMMS_BASE_URL = "https://api.audius.co"
 
 export interface RequestOptions {
   readonly query?: Record<string, string | number | boolean | undefined>
@@ -18,10 +25,89 @@ export interface RequestOptions {
   readonly headers?: Record<string, string>
 }
 
+/**
+ * Sign a payload for the Audius comms system (x-sig header).
+ *
+ * @noble/curves v2 "recovered" format returns [recovery, r(32), s(32)].
+ * The Audius SDK expects [r(32), s(32), recovery] so we rearrange.
+ */
+function signForComms(payload: string, privateKeyHex: string): string {
+  const hash = keccak_256(new TextEncoder().encode(payload))
+  const recovered = secp256k1.sign(hash, hexToBytes(privateKeyHex), { format: "recovered" })
+  const sigBytes = new Uint8Array(65)
+  sigBytes.set(recovered.subarray(1)) // r + s (64 bytes)
+  sigBytes[64] = recovered[0]         // recovery bit
+  let binary = ""
+  for (let i = 0; i < sigBytes.length; i++) {
+    binary += String.fromCharCode(sigBytes[i])
+  }
+  return btoa(binary)
+}
+
+/** Validate path to prevent SSRF via host hijacking. */
+function validatePath(path: string, label: string): Effect.Effect<void, Error> {
+  if (typeof path !== "string" || !path.startsWith("/") || path.includes("@")) {
+    return Effect.fail(new Error(`Invalid ${label} path: ${path}`))
+  }
+  return Effect.void
+}
+
+/** Build a URL with base and optional query params. */
+function buildUrl(base: string, path: string, query?: RequestOptions["query"]): URL {
+  const url = new URL(`${base}${path}`)
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) {
+        url.searchParams.set(key, String(value))
+      }
+    }
+  }
+  return url
+}
+
+/** Execute a fetch request, parse JSON, and map errors into Effect failures. */
+function fetchJson(
+  url: URL,
+  method: string,
+  headers: Record<string, string>,
+  body: unknown | undefined,
+  errorPrefix: string
+): Effect.Effect<unknown, Error> {
+  return Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(url.toString(), {
+          method,
+          headers,
+          body: body ? JSON.stringify(body) : undefined
+        }),
+      catch: (e) => new Error(`${errorPrefix} request failed: ${e}`)
+    })
+
+    if (!response.ok) {
+      const text = yield* Effect.tryPromise({
+        try: () => response.text(),
+        catch: () => new Error("Failed to read error response")
+      })
+      return yield* Effect.fail(new Error(`${errorPrefix} ${response.status}: ${text}`))
+    }
+
+    return yield* Effect.tryPromise({
+      try: () => response.json() as Promise<unknown>,
+      catch: (e) => new Error(`Failed to parse JSON response: ${e}`)
+    })
+  })
+}
+
 export class AudiusClient extends Context.Tag("AudiusClient")<
   AudiusClient,
   {
     readonly request: (
+      method: string,
+      path: string,
+      options?: RequestOptions
+    ) => Effect.Effect<unknown, Error>
+    readonly commsRequest: (
       method: string,
       path: string,
       options?: RequestOptions
@@ -34,66 +120,56 @@ export const AudiusClientLive: Layer.Layer<AudiusClient, never, AppConfig> = Lay
   Effect.gen(function* () {
     const config = yield* AppConfig
 
+    /** Build common headers (Accept, x-api-key, Content-Type). */
+    const baseHeaders = (
+      extra: Record<string, string> | undefined,
+      hasBody: boolean
+    ): Record<string, string> => {
+      const h: Record<string, string> = { "Accept": "application/json", ...extra }
+      if (config.apiKey) h["x-api-key"] = config.apiKey
+      if (hasBody) h["Content-Type"] = "application/json"
+      return h
+    }
+
     const request = (
       method: string,
       path: string,
       options?: RequestOptions
     ): Effect.Effect<unknown, Error> =>
       Effect.gen(function* () {
-        // Validate path to prevent SSRF via host hijacking
-        if (typeof path !== "string" || !path.startsWith("/") || path.includes("@")) {
-          return yield* Effect.fail(new Error(`Invalid API path: ${path}`))
-        }
-        // Build URL with query params
-        const url = new URL(`${BASE_URL}${path}`)
-        if (options?.query) {
-          for (const [key, value] of Object.entries(options.query)) {
-            if (value !== undefined) {
-              url.searchParams.set(key, String(value))
-            }
-          }
-        }
+        yield* validatePath(path, "API")
+        const url = buildUrl(BASE_URL, path, options?.query)
+        const headers = baseHeaders(options?.headers, !!options?.body)
+        return yield* fetchJson(url, method.toUpperCase(), headers, options?.body, "Audius API")
+      })
 
-        // Build headers
-        const headers: Record<string, string> = {
-          "Accept": "application/json",
-          ...options?.headers
-        }
-        if (config.apiKey) {
-          headers["x-api-key"] = config.apiKey
-        }
-        if (options?.body) {
-          headers["Content-Type"] = "application/json"
-        }
-
-        const response = yield* Effect.tryPromise({
-          try: () =>
-            fetch(url.toString(), {
-              method: method.toUpperCase(),
-              headers,
-              body: options?.body ? JSON.stringify(options.body) : undefined
-            }),
-          catch: (e) => new Error(`Audius API request failed: ${e}`)
-        })
-
-        if (!response.ok) {
-          const text = yield* Effect.tryPromise({
-            try: () => response.text(),
-            catch: () => new Error("Failed to read error response")
-          })
+    const commsRequest = (
+      method: string,
+      path: string,
+      options?: RequestOptions
+    ): Effect.Effect<unknown, Error> =>
+      Effect.gen(function* () {
+        if (!config.apiSecret) {
           return yield* Effect.fail(
-            new Error(`Audius API ${response.status}: ${text}`)
+            new Error("AUDIUS_API_SECRET is required for comms requests")
           )
         }
 
-        const json = yield* Effect.tryPromise({
-          try: () => response.json() as Promise<unknown>,
-          catch: (e) => new Error(`Failed to parse JSON response: ${e}`)
-        })
+        yield* validatePath(path, "comms")
+        const url = buildUrl(COMMS_BASE_URL, path, options?.query)
 
-        return json
+        // GET signs the path+query; POST signs the JSON body
+        const upperMethod = method.toUpperCase()
+        const sigPayload = (upperMethod === "POST" && options?.body)
+          ? JSON.stringify(options.body)
+          : url.pathname + url.search
+
+        const headers = baseHeaders(options?.headers, !!options?.body)
+        headers["x-sig"] = signForComms(sigPayload, config.apiSecret)
+
+        return yield* fetchJson(url, upperMethod, headers, options?.body, "Audius comms")
       })
 
-    return { request }
+    return { request, commsRequest }
   })
 )


### PR DESCRIPTION
## Summary
- Adds `commsRequest()` method to `AudiusClient` for the `/comms/` messaging system, which uses `x-sig` header authentication (secp256k1 + keccak256 signing)
- Adds `apiSecret` (from `AUDIUS_API_SECRET` env var) to `AppConfig` for the signing private key
- Extracts shared helpers (`validatePath`, `buildUrl`, `fetchJson`, `baseHeaders`) to eliminate duplication between `request()` and `commsRequest()`

## Test plan
- [x] TypeScript compilation passes (`pnpm build`)
- [ ] E2E testing deferred to Unit 2B

🤖 Generated with [Claude Code](https://claude.com/claude-code)