### PR TITLE
Release 2 — Make It Good (AX-09, 02, 04, 06, 19, 20, 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ server into alignment with the 2026-05-21 agent-experience study. Restores the m
   captured; an unwrapped `console.error` no longer throws and kills the execution.
 - **AX-24** — behavioral test suite (`pnpm test` now builds, then runs `node --test`).
 
+### Release 2 — Make It Good
+- **AX-09** — typed error model (`src/api/Errors.ts`): API failures resolve inside the
+  sandbox as recovery directives `{ ok:false, errorType, status, message, context,
+  nextActions, prohibition }` instead of a JSON-string nested in a string. Success
+  responses are unchanged.
+- **AX-02** — default projection (`src/api/Projection.ts`): `audius.request` responses
+  have heavy media / wallet / CID keys stripped unless the caller passes `{ raw:true }`,
+  `{ detail:"full" }`, or `{ fields:[...] }` (dot-path projection).
+- **AX-04** — projection announces itself: when keys are dropped, a `[projection] …`
+  note is added to the execute output.
+- **AX-06** — new `inspect_endpoint` tool: one endpoint in depth — parameters, response
+  schema, the `{data}` envelope, an `requiresAuth` flag, and a runnable example.
+- **AX-19** — learning surface exposed as resources: `audius://api/types` (the generated
+  TypeScript declarations) and `audius://sandbox/runtime` (the sandbox manifest).
+- **AX-20** — five workflow recipes registered as MCP prompts (`audius-rising-stars`,
+  `audius-genre-report`, `audius-artist-compare`, `audius-hidden-gems`,
+  `audius-bpm-landscape`); the `prompts` capability is now declared.
+- **AX-10** — sandbox reliability: each `audius.request` is bounded by a 10 s host
+  timeout, and an execute call may make at most 64 requests (`REQUEST_BUDGET`).
+
 ## 2.4.0 (2025-07-01)
 - Added stream-track and open-track-in-desktop tools for direct audio streaming.
 - Introduced AUDIO_STREAMING configuration option.

--- a/src/api/Errors.ts
+++ b/src/api/Errors.ts
@@ -1,0 +1,147 @@
+/**
+ * Errors.ts — typed, agent-directed error model (AX-09).
+ *
+ * Tool errors are read by the model, not a human: an error is a recovery
+ * script. This module turns an Audius API failure into a structured
+ * directive — a named errorType, recovery context, and explicit nextActions —
+ * instead of a JSON-string nested inside a string.
+ */
+
+export type ErrorType =
+  | "AUTH_REQUIRED"
+  | "RATE_LIMITED"
+  | "NOT_FOUND"
+  | "BAD_PARAMS"
+  | "BAD_PATH"
+  | "UPSTREAM_ERROR"
+  | "TIMEOUT"
+  | "REQUEST_BUDGET"
+  | "SUBGRAPH_UNCONFIGURED"
+
+export interface ErrorDirective {
+  readonly ok: false
+  readonly errorType: ErrorType
+  readonly status: number
+  readonly message: string
+  readonly context: { path?: string; method?: string }
+  readonly nextActions: string[]
+  readonly prohibition: string
+  readonly retryAfter?: number
+}
+
+function mapStatus(status: number): ErrorType {
+  if (status === 401 || status === 403) return "AUTH_REQUIRED"
+  if (status === 404) return "NOT_FOUND"
+  if (status === 429) return "RATE_LIMITED"
+  if (status === 400 || status === 422) return "BAD_PARAMS"
+  return "UPSTREAM_ERROR"
+}
+
+const NEXT_ACTIONS: Record<ErrorType, string[]> = {
+  AUTH_REQUIRED: [
+    "This endpoint needs a user bearer token, which this session does not have.",
+    "Tell the user the action requires connecting their Audius account, or use a public endpoint instead."
+  ],
+  RATE_LIMITED: [
+    "The Audius API rate-limited this request — an upstream limit, not a bug in your code.",
+    "Wait briefly and retry; if looping, reduce the number of requests per execute call."
+  ],
+  NOT_FOUND: [
+    "The path or resource id does not exist.",
+    "Re-check the id, or use the search / inspect_endpoint tools to find the correct path."
+  ],
+  BAD_PARAMS: [
+    "The request parameters were rejected by the API.",
+    "Use inspect_endpoint on this path to see the exact parameter names, types, and an example."
+  ],
+  BAD_PATH: [
+    "The API path was malformed (paths must start with '/').",
+    "Use the search tool to find a valid endpoint path."
+  ],
+  UPSTREAM_ERROR: [
+    "The Audius API returned an unexpected error.",
+    "Retry once; if it persists the upstream service may be degraded."
+  ],
+  TIMEOUT: [
+    "The request exceeded its time budget.",
+    "Retry, or split the work into fewer / smaller calls."
+  ],
+  REQUEST_BUDGET: [
+    "This execute call hit its request budget (too many audius.request calls).",
+    "Batch or aggregate: fetch less data, or paginate with a smaller total."
+  ],
+  SUBGRAPH_UNCONFIGURED: [
+    "The subgraph tool is not configured on this deployment (no Graph API key).",
+    "Use the REST API via execute for content data; subgraph covers only on-chain protocol data."
+  ]
+}
+
+export interface BuildErrorOptions {
+  status: number
+  errorType?: ErrorType
+  message: string
+  path?: string
+  method?: string
+  retryAfter?: number
+}
+
+/** Build a structured recovery directive. */
+export function buildErrorDirective(opts: BuildErrorOptions): ErrorDirective {
+  const errorType = opts.errorType ?? mapStatus(opts.status)
+  return {
+    ok: false,
+    errorType,
+    status: opts.status,
+    message: opts.message,
+    context: { path: opts.path, method: opts.method },
+    nextActions: NEXT_ACTIONS[errorType],
+    prohibition:
+      "Do not retry this call verbatim — it will fail identically. Change something first.",
+    ...(opts.retryAfter !== undefined ? { retryAfter: opts.retryAfter } : {})
+  }
+}
+
+/**
+ * Parse a failure thrown by AudiusClient ("Audius API <status>: <body>")
+ * into a structured directive. Falls back to UPSTREAM_ERROR / TIMEOUT when
+ * the message is not in that shape.
+ */
+export function directiveFromError(
+  err: unknown,
+  path?: string,
+  method?: string
+): ErrorDirective {
+  const raw = err instanceof Error ? err.message : String(err)
+
+  const m = /Audius API (\d+): ([\s\S]*)/.exec(raw)
+  if (m) {
+    const status = parseInt(m[1], 10)
+    let message = m[2].trim()
+    // The body is often itself JSON like {"code":401,"error":"..."}.
+    try {
+      const parsed = JSON.parse(message) as { error?: unknown }
+      if (parsed && typeof parsed.error === "string") message = parsed.error
+    } catch {
+      // leave message as the raw body
+    }
+    return buildErrorDirective({ status, message, path, method })
+  }
+
+  if (/timed out|timeout/i.test(raw)) {
+    return buildErrorDirective({
+      status: 0,
+      errorType: "TIMEOUT",
+      message: raw,
+      path,
+      method
+    })
+  }
+
+  return buildErrorDirective({
+    status: 0,
+    errorType: "UPSTREAM_ERROR",
+    message: raw,
+    path,
+    method
+  })
+}

--- a/src/api/Projection.ts
+++ b/src/api/Projection.ts
@@ -1,0 +1,132 @@
+/**
+ * Projection.ts — the default projection layer (AX-02).
+ *
+ * Audius API responses are fat: a single track is ~6 KB and most of it is
+ * artwork mirror arrays, signed stream URLs, CID hashes and wallet addresses —
+ * bytes no agent reasoning step consumes. By default the sandbox strips these
+ * heavy, low-signal keys before a result crosses back to the model.
+ *
+ * Opt out per call:  options.raw === true   or   options.detail === "full"
+ * Project precisely: options.fields = ["data.title", "data.user.name", ...]
+ *
+ * This is a defence-in-depth layer beneath the ResponseGuard cap (AX-01a):
+ * projection keeps the common case small; the cap guarantees the worst case.
+ */
+
+/** Heavy / low-signal keys stripped at the default detail level. */
+const HEAVY_KEYS = new Set<string>([
+  "artwork", "cover_art", "cover_art_sizes", "cover_photo", "cover_photo_sizes",
+  "cover_photo_cids", "cover_photo_legacy", "profile_picture", "profile_picture_sizes",
+  "profile_picture_cids", "profile_picture_legacy",
+  "stream", "download", "preview", "track_cid", "orig_file_cid", "preview_cid",
+  "orig_filename", "field_visibility", "track_segments", "audio_upload_id",
+  "blocknumber", "erc_wallet", "spl_wallet", "spl_usdc_wallet", "spl_usdc_payout_wallet",
+  "payout_wallet", "associated_wallets_balance", "associated_sol_wallets_balance",
+  "creator_node_endpoint", "ddex_app", "ddex_release_ids", "audio_analysis_error_count"
+])
+
+export interface ProjectionOptions {
+  raw?: boolean
+  detail?: "minimal" | "standard" | "full"
+  fields?: string[]
+}
+
+export interface ProjectionOutcome {
+  readonly value: unknown
+  readonly projected: boolean
+  readonly note?: string
+}
+
+function stripHeavy(value: unknown, dropped: Set<string>): unknown {
+  if (Array.isArray(value)) {
+    return value.map((v) => stripHeavy(v, dropped))
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (HEAVY_KEYS.has(k)) {
+        dropped.add(k)
+        continue
+      }
+      out[k] = stripHeavy(v, dropped)
+    }
+    return out
+  }
+  return value
+}
+
+/** Navigate a dot-path, mapping element-wise across any array crossed. */
+function pickPath(value: unknown, segments: string[]): unknown {
+  if (segments.length === 0) return value
+  if (Array.isArray(value)) {
+    return value.map((v) => pickPath(v, segments))
+  }
+  if (value && typeof value === "object") {
+    const head = segments[0]
+    const child = (value as Record<string, unknown>)[head]
+    return { [head]: pickPath(child, segments.slice(1)) }
+  }
+  return undefined
+}
+
+function deepMerge(a: unknown, b: unknown): unknown {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.map((el, i) => (i < b.length ? deepMerge(el, b[i]) : el))
+  }
+  if (a && b && typeof a === "object" && typeof b === "object" && !Array.isArray(a)) {
+    const out: Record<string, unknown> = { ...(a as Record<string, unknown>) }
+    for (const [k, v] of Object.entries(b as Record<string, unknown>)) {
+      out[k] = k in out ? deepMerge(out[k], v) : v
+    }
+    return out
+  }
+  return b ?? a
+}
+
+/**
+ * Apply projection to an API response value. Returns the (possibly trimmed)
+ * value plus an honest note describing what the membrane did (AX-04).
+ *
+ * `options` is the raw options object the agent passed to audius.request —
+ * projection reads `raw`, `detail`, and `fields` from it and ignores the rest.
+ */
+export function project(
+  value: unknown,
+  options: Record<string, unknown> = {}
+): ProjectionOutcome {
+  const raw = options["raw"] === true
+  const detail = options["detail"]
+  const fields = Array.isArray(options["fields"])
+    ? (options["fields"] as unknown[]).filter((f): f is string => typeof f === "string")
+    : undefined
+
+  if (raw || detail === "full") {
+    return { value, projected: false }
+  }
+
+  if (fields && fields.length > 0) {
+    let acc: unknown = undefined
+    for (const f of fields) {
+      const picked = pickPath(value, f.split("."))
+      acc = acc === undefined ? picked : deepMerge(acc, picked)
+    }
+    return {
+      value: acc,
+      projected: true,
+      note: `projected to fields [${fields.join(", ")}]`
+    }
+  }
+
+  const dropped = new Set<string>()
+  const stripped = stripHeavy(value, dropped)
+  if (dropped.size === 0) {
+    return { value: stripped, projected: false }
+  }
+  return {
+    value: stripped,
+    projected: true,
+    note:
+      `dropped ${dropped.size} heavy key type(s) [${[...dropped].sort().join(", ")}] — ` +
+      `pass { raw: true } in options for the full response`
+  }
+}

--- a/src/api/SpecIndex.ts
+++ b/src/api/SpecIndex.ts
@@ -268,6 +268,8 @@ export class SpecIndex extends Context.Tag("SpecIndex")<
     readonly search: (filters: SearchFilters) => SearchResult
     readonly getAllTags: () => string[]
     readonly getEndpointCount: () => number
+    /** Full metadata for one endpoint (AX-06 — backs inspect_endpoint). */
+    readonly getEndpoint: (path: string, method: string) => EndpointMeta | undefined
   }
 >() {}
 
@@ -279,12 +281,24 @@ export const SpecIndexLive: Layer.Layer<SpecIndex, never, SpecLoader> = Layer.ef
 
     const allTags = [...new Set(index.flatMap((e) => e.tags))].sort()
 
+    // Exact-match lookup for inspect_endpoint, keyed "METHOD /path".
+    const byKey = new Map<string, IndexedEndpoint>()
+    for (const e of index) {
+      byKey.set(`${e.method} ${e.path.toLowerCase()}`, e)
+    }
+
     yield* Effect.logInfo(`Built spec index: ${index.length} endpoints across ${allTags.length} tags`)
 
     return {
       search: (filters: SearchFilters) => searchEndpoints(index, filters),
       getAllTags: () => allTags,
-      getEndpointCount: () => index.length
+      getEndpointCount: () => index.length,
+      getEndpoint: (path: string, method: string): EndpointMeta | undefined => {
+        const found = byKey.get(`${method.toUpperCase()} ${path.toLowerCase()}`)
+        if (!found) return undefined
+        const { searchText: _ignored, ...rest } = found
+        return rest
+      }
     }
   })
 )

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { AppConfig, AppConfigLive } from "./AppConfig.js"
 import { SpecLoaderLive } from "./api/SpecLoader.js"
 import { SpecIndex, SpecIndexLive } from "./api/SpecIndex.js"
 import { AudiusClient, AudiusClientLive } from "./api/AudiusClient.js"
-import { TypeGeneratorLive } from "./sandbox/TypeGenerator.js"
+import { TypeGenerator, TypeGeneratorLive } from "./sandbox/TypeGenerator.js"
 import { Sandbox, SandboxLive } from "./sandbox/Sandbox.js"
 import { createHandler } from "./mcp/McpServer.js"
 import { startServer } from "./mcp/McpServerTransport.js"
@@ -45,12 +45,15 @@ const SandboxLayer = SandboxLive.pipe(
   Layer.provide(Layer.merge(AudiusClientLayer, TypeGeneratorLayer))
 )
 
-// Full application layer — provides AppConfig, SpecIndex, Sandbox, AudiusClient
+// Full application layer — provides AppConfig, SpecIndex, Sandbox,
+// AudiusClient, and TypeGenerator (the last so the handler can serve the
+// audius://api/types resource).
 const AppLayer = Layer.mergeAll(
   AppConfigLive,
   SpecIndexLayer,
   SandboxLayer,
-  AudiusClientLayer
+  AudiusClientLayer,
+  TypeGeneratorLayer
 )
 
 // ---------------------------------------------------------------------------
@@ -65,7 +68,7 @@ const program = Effect.gen(function* () {
 
   // Build a runtime with all services provided, so we can run Effects
   // from within the async HTTP handler
-  const runtime = yield* Effect.runtime<AppConfig | SpecIndex | Sandbox | AudiusClient>()
+  const runtime = yield* Effect.runtime<AppConfig | SpecIndex | Sandbox | AudiusClient | TypeGenerator>()
 
   // Bridge Effect handler → async handler for the transport
   const asyncHandler = async (decoded: unknown, bearerToken?: string): Promise<unknown> => {

--- a/src/mcp/McpServer.ts
+++ b/src/mcp/McpServer.ts
@@ -19,9 +19,12 @@ import { searchToolDefinition, handleSearch } from "../tools/SearchTool.js"
 import { executeToolDefinition, handleExecute } from "../tools/ExecuteTool.js"
 import { playToolDefinition, handlePlay } from "../tools/PlayTool.js"
 import { subgraphToolDefinition, handleSubgraph } from "../tools/SubgraphTool.js"
+import { inspectEndpointToolDefinition, handleInspectEndpoint } from "../tools/InspectEndpointTool.js"
 import { workflowsResource, WORKFLOWS_URI, WORKFLOWS_CONTENT } from "../resources/Workflows.js"
+import { TypeGenerator } from "../sandbox/TypeGenerator.js"
 import { CallToolResult } from "./McpSchema.js"
 import { capResult } from "./ResponseGuard.js"
+import { listPrompts, getPrompt, buildPromptResult } from "./Prompts.js"
 
 // ---------------------------------------------------------------------------
 // Server info
@@ -46,15 +49,18 @@ calls them — instead of facing hundreds of individual tools.
 1. **search** — find Audius API endpoints. Returns compact ranked rows
    (method, path, summary, tags). Filter by \`tag\`, \`query\`, \`path\`, or \`method\`;
    call with no filter for the list of tags.
-2. **execute** — run JavaScript in a sandbox. An authenticated \`audius\` client is
+2. **inspect_endpoint** — describe one endpoint in depth: parameters, response
+   schema, whether it needs auth, and a runnable example. Use after \`search\`.
+3. **execute** — run JavaScript in a sandbox. An authenticated \`audius\` client is
    available: \`audius.request(method, path, options?)\`. \`console.log()\` is
    captured; the value you \`return\` is the result.
-3. **play** — resolve a track (by id or search query) to its Audius URLs.
-4. **subgraph** — query the Audius protocol subgraph (on-chain staking, governance).
+4. **play** — resolve a track (by id or search query) to its Audius URLs.
+5. **subgraph** — query the Audius protocol subgraph (on-chain staking, governance).
 
 ## Recommended workflow
 1. \`search({ tag: "tracks" })\` — discover the endpoints you need.
-2. \`execute(...)\` — call them, and REDUCE the data before returning.
+2. \`inspect_endpoint({ path })\` — check one endpoint's exact params (optional).
+3. \`execute(...)\` — call them, and REDUCE the data before returning.
 
 ## CRITICAL: the sandbox is a reducer, not a pipe
 Your \`execute\` return value is charged to the model's context window, and Audius
@@ -90,8 +96,65 @@ audius.request("GET", "/tracks/search", { query: "deadmau5" })
 ## Ready-made recipes
 The \`audius://workflows\` resource holds 13 ready-to-run analysis recipes — genre
 popularity, rising stars, artist comparison, BPM landscape and more — each a single
-\`execute\` call that reduces data correctly. Read it and adapt.
+\`execute\` call that reduces data correctly. Read it and adapt. Several are also
+available as prompts (\`audius-rising-stars\`, \`audius-genre-report\`, …).
+
+## More references
+- \`audius://api/types\` — generated type declarations for every Audius endpoint.
+- \`audius://sandbox/runtime\` — what the execute sandbox provides, and its limits.
+- API responses are projected by default (heavy media / wallet / CID fields are
+  stripped); pass \`{ raw: true }\` in \`options\` for the untrimmed payload.
+- API failures return a typed directive \`{ ok: false, errorType, nextActions, … }\` —
+  read it and act on \`nextActions\`; do not retry verbatim.
 `.trim()
+
+// ---------------------------------------------------------------------------
+// Resources — the learning surface (AX-19)
+// ---------------------------------------------------------------------------
+
+const API_TYPES_URI = "audius://api/types"
+const SANDBOX_RUNTIME_URI = "audius://sandbox/runtime"
+
+const apiTypesResource = {
+  uri: API_TYPES_URI,
+  name: "Audius API Type Declarations",
+  description:
+    "Generated TypeScript declarations for every Audius API endpoint — the full " +
+    "surface available to audius.request() in the execute sandbox.",
+  mimeType: "text/plain"
+}
+
+const sandboxRuntimeResource = {
+  uri: SANDBOX_RUNTIME_URI,
+  name: "Sandbox Runtime Manifest",
+  description:
+    "What the execute QuickJS sandbox provides and lacks — globals, the audius " +
+    "client contract, projection behaviour, and resource limits.",
+  mimeType: "application/json"
+}
+
+const SANDBOX_RUNTIME_MANIFEST = {
+  engine: "QuickJS (WASM)",
+  memoryLimitMB: 64,
+  defaultTimeoutMs: 30000,
+  freshContextPerCall: true,
+  present: [
+    "Date", "Math", "JSON", "RegExp", "Map", "Set", "WeakMap", "WeakSet",
+    "Promise", "Proxy", "Reflect", "TypedArrays",
+    "console.log", "console.error", "console.warn", "console.info", "console.debug"
+  ],
+  absent: ["fetch", "setTimeout", "crypto", "TextEncoder", "TextDecoder"],
+  provided: {
+    "audius.request(method, path, options?)":
+      "Calls the Audius API. On success returns the JSON response, projected by " +
+      "default (heavy media/wallet/CID fields stripped — pass { raw: true } in " +
+      "options for the full payload, or { fields: ['data.title', ...] } to pick). " +
+      "On failure returns a typed directive { ok: false, errorType, nextActions, ... }.",
+    "console.*": "log / error / warn / info / debug are all captured and returned."
+  },
+  responseEnvelope: "Audius list endpoints wrap their payload as { data: [ ... ] }.",
+  limits: { requestBudgetPerExecute: 64, perRequestTimeoutMs: 10000 }
+}
 
 // ---------------------------------------------------------------------------
 // Handler
@@ -103,10 +166,10 @@ popularity, rising stars, artist comparison, BPM landscape and more — each a s
  * Takes an internal Effect RPC message (decoded by McpSerialization)
  * and returns the response in internal format.
  */
-export type McpEffectHandler = (decoded: unknown, bearerToken?: string) => Effect.Effect<unknown, never, AppConfig | SpecIndex | Sandbox | AudiusClient>
+export type McpEffectHandler = (decoded: unknown, bearerToken?: string) => Effect.Effect<unknown, never, AppConfig | SpecIndex | Sandbox | AudiusClient | TypeGenerator>
 
 export const createHandler = (): McpEffectHandler => {
-  return (decoded: unknown, bearerToken?: string): Effect.Effect<unknown, never, AppConfig | SpecIndex | Sandbox | AudiusClient> => {
+  return (decoded: unknown, bearerToken?: string): Effect.Effect<unknown, never, AppConfig | SpecIndex | Sandbox | AudiusClient | TypeGenerator> => {
     const msg = decoded as Record<string, unknown>
     const tag = msg["tag"] as string
     const id = msg["id"] as string
@@ -123,7 +186,8 @@ export const createHandler = (): McpEffectHandler => {
           protocolVersion: PROTOCOL_VERSION,
           capabilities: {
             tools: {},
-            resources: {}
+            resources: {},
+            prompts: {}
           },
           serverInfo: SERVER_INFO,
           instructions: INSTRUCTIONS
@@ -136,6 +200,7 @@ export const createHandler = (): McpEffectHandler => {
         return Effect.succeed(makeResponse(id, {
           tools: [
             stripMake(searchToolDefinition),
+            stripMake(inspectEndpointToolDefinition),
             stripMake(executeToolDefinition),
             stripMake(playToolDefinition),
             stripMake(subgraphToolDefinition)
@@ -151,7 +216,7 @@ export const createHandler = (): McpEffectHandler => {
 
       case "resources/list":
         return Effect.succeed(makeResponse(id, {
-          resources: [workflowsResource]
+          resources: [workflowsResource, apiTypesResource, sandboxRuntimeResource]
         }))
 
       case "resources/read": {
@@ -165,6 +230,27 @@ export const createHandler = (): McpEffectHandler => {
             }]
           }))
         }
+        if (uri === SANDBOX_RUNTIME_URI) {
+          return Effect.succeed(makeResponse(id, {
+            contents: [{
+              uri: SANDBOX_RUNTIME_URI,
+              mimeType: "application/json",
+              text: JSON.stringify(SANDBOX_RUNTIME_MANIFEST, null, 2)
+            }]
+          }))
+        }
+        if (uri === API_TYPES_URI) {
+          return Effect.gen(function* () {
+            const typeGen = yield* TypeGenerator
+            return makeResponse(id, {
+              contents: [{
+                uri: API_TYPES_URI,
+                mimeType: "text/plain",
+                text: typeGen.declarations
+              }]
+            })
+          })
+        }
         return Effect.succeed(makeErrorResponse(id, -32602, `Resource not found: ${uri}`))
       }
 
@@ -172,7 +258,20 @@ export const createHandler = (): McpEffectHandler => {
         return Effect.succeed(makeResponse(id, { resourceTemplates: [] }))
 
       case "prompts/list":
-        return Effect.succeed(makeResponse(id, { prompts: [] }))
+        return Effect.succeed(makeResponse(id, { prompts: listPrompts() }))
+
+      case "prompts/get": {
+        const p = payload ?? {}
+        const promptName = p["name"] as string
+        const promptArgs = (p["arguments"] as Record<string, string>) ?? {}
+        const def = getPrompt(promptName)
+        if (!def) {
+          return Effect.succeed(
+            makeErrorResponse(id, -32602, `Prompt not found: ${promptName}`)
+          )
+        }
+        return Effect.succeed(makeResponse(id, buildPromptResult(def, promptArgs)))
+      }
 
       case "completion/complete":
         return Effect.succeed(makeResponse(id, {
@@ -193,7 +292,7 @@ function handleToolCall(
   id: string,
   payload: Record<string, unknown>,
   bearerToken?: string
-): Effect.Effect<unknown, never, AppConfig | SpecIndex | Sandbox | AudiusClient> {
+): Effect.Effect<unknown, never, AppConfig | SpecIndex | Sandbox | AudiusClient | TypeGenerator> {
   return Effect.gen(function* () {
     const config = yield* AppConfig
     const name = payload["name"] as string
@@ -203,6 +302,9 @@ function handleToolCall(
     switch (name) {
       case "search":
         result = yield* handleSearch(args)
+        break
+      case "inspect_endpoint":
+        result = yield* handleInspectEndpoint(args)
         break
       case "execute":
         result = yield* handleExecute(args, bearerToken)

--- a/src/mcp/Prompts.ts
+++ b/src/mcp/Prompts.ts
@@ -1,0 +1,164 @@
+/**
+ * Prompts.ts — the workflow recipes as MCP prompts (AX-20).
+ *
+ * Each prompt hands the agent a projection-correct `execute` body for a
+ * common analysis task, so the good path is one step away. Prompts cost
+ * zero tool-call surface — they are not tools.
+ */
+
+export interface PromptArg {
+  readonly name: string
+  readonly description: string
+  readonly required: boolean
+}
+
+export interface PromptDef {
+  readonly name: string
+  readonly description: string
+  readonly arguments: PromptArg[]
+  /** Build the execute()-ready code body from the supplied arguments. */
+  readonly build: (args: Record<string, string>) => string
+}
+
+const arg = (name: string, description: string, required = false): PromptArg => ({
+  name,
+  description,
+  required
+})
+
+/** Strip single quotes so an argument cannot break out of the code template. */
+const safe = (s: string | undefined, fallback: string): string =>
+  (s ?? fallback).replace(/['"`\\]/g, "")
+
+export const PROMPTS: PromptDef[] = [
+  {
+    name: "audius-rising-stars",
+    description: "Find breakout artists — trending tracks by low-follower, unverified artists.",
+    arguments: [arg("genre", "Genre to filter by, e.g. 'Electronic' (optional)")],
+    build: (a) => {
+      const genre = a["genre"] ? `, genre: '${safe(a["genre"], "")}'` : ""
+      return `const t = await audius.request('GET', '/tracks/trending', { query: { limit: 100${genre} } });
+const seen = {};
+for (const x of t.data) {
+  const u = x.user; if (!u) continue;
+  if (!seen[u.id] || x.play_count > seen[u.id].plays)
+    seen[u.id] = { name: u.name, handle: u.handle, followers: u.follower_count, verified: u.is_verified, plays: x.play_count, track: x.title };
+}
+return Object.values(seen)
+  .filter(a => !a.verified && a.followers < 2000)
+  .sort((a, b) => b.plays - a.plays)
+  .slice(0, 10);`
+    }
+  },
+  {
+    name: "audius-genre-report",
+    description: "Profile one genre from current trending — key tracks, avg BPM, dominant moods.",
+    arguments: [arg("genre", "Genre to profile, e.g. 'Electronic'", true)],
+    build: (a) => {
+      const genre = safe(a["genre"], "Electronic")
+      return `const GENRE = '${genre}';
+const t = await audius.request('GET', '/tracks/trending', { query: { limit: 100 } });
+const g = t.data.filter(x => x.genre === GENRE);
+const moods = {}; let bpm = 0, n = 0;
+for (const x of g) { if (x.mood) moods[x.mood] = (moods[x.mood] || 0) + 1; if (x.bpm) { bpm += x.bpm; n++; } }
+return {
+  genre: GENRE, trackCount: g.length,
+  avgBpm: n ? Math.round(bpm / n) : null,
+  topMoods: Object.entries(moods).sort((a, b) => b[1] - a[1]).slice(0, 5),
+  topTracks: g.sort((a, b) => b.play_count - a.play_count).slice(0, 5)
+    .map(x => ({ title: x.title, artist: x.user.name, plays: x.play_count }))
+};`
+    }
+  },
+  {
+    name: "audius-artist-compare",
+    description: "Compare two artists across followers, catalog size, plays and engagement.",
+    arguments: [
+      arg("artist_a", "First artist name", true),
+      arg("artist_b", "Second artist name", true)
+    ],
+    build: (a) => {
+      const A = safe(a["artist_a"], "deadmau5")
+      const B = safe(a["artist_b"], "Skrillex")
+      return `async function profile(q) {
+  const s = await audius.request('GET', '/users/search', { query: { query: q } });
+  const u = (s.data || []).find(x => x.is_verified) || (s.data || [])[0];
+  if (!u) return { query: q, found: false };
+  const t = await audius.request('GET', '/users/' + u.id + '/tracks');
+  const plays = (t.data || []).reduce((s, x) => s + (x.play_count || 0), 0);
+  const favs = (t.data || []).reduce((s, x) => s + (x.favorite_count || 0), 0);
+  return { name: u.name, followers: u.follower_count, tracks: (t.data || []).length,
+           totalPlays: plays, engagementRate: plays ? (favs / plays * 100).toFixed(2) + '%' : '0%' };
+}
+return { comparison: [await profile('${A}'), await profile('${B}')] };`
+    }
+  },
+  {
+    name: "audius-hidden-gems",
+    description: "Trending tracks with the highest engagement-to-play ratio — underexposed favourites.",
+    arguments: [],
+    build: () =>
+      `const t = await audius.request('GET', '/tracks/trending', { query: { limit: 100 } });
+return t.data
+  .filter(x => x.play_count > 10)
+  .map(x => ({ title: x.title, artist: x.user.name, plays: x.play_count,
+    engagement: ((x.favorite_count + x.repost_count) / x.play_count * 100).toFixed(1) + '%',
+    score: (x.favorite_count + x.repost_count) / x.play_count }))
+  .sort((a, b) => b.score - a.score)
+  .slice(0, 10);`
+  },
+  {
+    name: "audius-bpm-landscape",
+    description: "Map the BPM spectrum of trending tracks — hot zones, dead zones, the sweet spot.",
+    arguments: [],
+    build: () =>
+      `const t = await audius.request('GET', '/tracks/trending', { query: { limit: 100 } });
+const tracks = t.data.filter(x => x.bpm > 0);
+const buckets = {};
+for (const x of tracks) {
+  const b = Math.floor(x.bpm / 10) * 10;
+  (buckets[b] = buckets[b] || []).push(x.play_count);
+}
+return Object.entries(buckets)
+  .map(([b, plays]) => ({ range: b + '-' + (Number(b) + 9) + ' BPM', count: plays.length,
+    avgPlays: Math.round(plays.reduce((s, p) => s + p, 0) / plays.length) }))
+  .sort((a, b) => parseInt(a.range) - parseInt(b.range));`
+  }
+]
+
+export function getPrompt(name: string): PromptDef | undefined {
+  return PROMPTS.find((p) => p.name === name)
+}
+
+/** The `prompts/list` payload. */
+export function listPrompts(): Array<{
+  name: string
+  description: string
+  arguments: PromptArg[]
+}> {
+  return PROMPTS.map((p) => ({
+    name: p.name,
+    description: p.description,
+    arguments: p.arguments
+  }))
+}
+
+/** The `prompts/get` payload for a prompt + its arguments. */
+export function buildPromptResult(
+  p: PromptDef,
+  args: Record<string, string>
+): {
+  description: string
+  messages: Array<{ role: "user"; content: { type: "text"; text: string } }>
+} {
+  const code = p.build(args)
+  const text =
+    `Run this with the \`execute\` tool — a projection-correct recipe for: ${p.description}\n\n` +
+    "```js\n" +
+    code +
+    "\n```"
+  return {
+    description: p.description,
+    messages: [{ role: "user", content: { type: "text", text } }]
+  }
+}

--- a/src/sandbox/Sandbox.ts
+++ b/src/sandbox/Sandbox.ts
@@ -19,6 +19,8 @@ import { Context, Effect, Layer } from "effect"
 import { getQuickJS } from "quickjs-emscripten"
 import { AudiusClient } from "../api/AudiusClient.js"
 import { TypeGenerator } from "./TypeGenerator.js"
+import { project } from "../api/Projection.js"
+import { buildErrorDirective, directiveFromError } from "../api/Errors.js"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,6 +34,11 @@ export interface SandboxResult {
 
 const DEFAULT_TIMEOUT_MS = 30_000
 const MEMORY_LIMIT_BYTES = 64 * 1024 * 1024 // 64MB
+
+/** AX-10 — max audius.request calls per single execute. */
+const REQUEST_BUDGET = 64
+/** AX-10 — max wall-clock time for one host-side API call. */
+const PER_REQUEST_TIMEOUT_MS = 10_000
 
 // ---------------------------------------------------------------------------
 // Service
@@ -110,6 +117,11 @@ export const SandboxLive: Layer.Layer<Sandbox, Error, AudiusClient | TypeGenerat
             // host-side API call, and returns the promise handle to the VM.
             // When the API call resolves, we settle the deferred and pump
             // executePendingJobs to advance the VM's promise chain.
+            // AX-02 — successful responses are projected (heavy keys stripped).
+            // AX-09 — failures become typed recovery directives.
+            // AX-10 — each call is time-bounded and counted against a budget.
+            let requestCount = 0
+
             const audiusHandle = ctx.newObject()
             const requestFn = ctx.newFunction("request", (...args) => {
               const method = ctx.dump(args[0]) as string
@@ -118,33 +130,64 @@ export const SandboxLive: Layer.Layer<Sandbox, Error, AudiusClient | TypeGenerat
 
               const deferred = ctx.newPromise()
 
-              // Kick off the host-side API call asynchronously
+              const settle = (payload: unknown) => {
+                const strHandle = ctx.newString(JSON.stringify(payload))
+                deferred.resolve(strHandle)
+                strHandle.dispose()
+                // Pump the VM event loop so the .then() handlers run
+                ctx.runtime.executePendingJobs()
+              }
+
+              // AX-10 — per-execution request budget.
+              requestCount++
+              if (requestCount > REQUEST_BUDGET) {
+                const directive = buildErrorDirective({
+                  status: 0,
+                  errorType: "REQUEST_BUDGET",
+                  message:
+                    `Request budget of ${REQUEST_BUDGET} audius.request calls ` +
+                    `exceeded in one execute.`,
+                  path,
+                  method
+                })
+                pendingPromises.push(Promise.resolve().then(() => settle(directive)))
+                return deferred.handle
+              }
+
               const resolvedAuth = authContext?.bearerToken
                 ? { bearerToken: authContext.bearerToken }
                 : undefined
-              const hostPromise = Effect.runPromise(
-                audiusClient.request(method, path, options as any, resolvedAuth)
-              ).then(
+
+              // AX-10 — bound each host fetch so a hung call cannot exceed the budget.
+              const timed = new Promise<unknown>((resolve, reject) => {
+                const timer = setTimeout(
+                  () => reject(new Error("request timed out")),
+                  PER_REQUEST_TIMEOUT_MS
+                )
+                Effect.runPromise(
+                  audiusClient.request(method, path, options as any, resolvedAuth)
+                ).then(
+                  (r) => { clearTimeout(timer); resolve(r) },
+                  (e) => { clearTimeout(timer); reject(e) }
+                )
+              })
+
+              const hostPromise = timed.then(
                 (result) => {
-                  const jsonStr = JSON.stringify(result)
-                  const strHandle = ctx.newString(jsonStr)
-                  deferred.resolve(strHandle)
-                  strHandle.dispose()
-                  // Pump the VM event loop so the .then() handlers run
-                  ctx.runtime.executePendingJobs()
+                  // AX-02 — strip heavy keys unless the caller opted out.
+                  const outcome = project(result, options ?? {})
+                  if (outcome.note) {
+                    output.push(`[projection] ${outcome.note}`)
+                  }
+                  settle(outcome.value)
                 },
                 (e) => {
-                  const errorMsg = e instanceof Error ? e.message : String(e)
-                  const jsonStr = JSON.stringify({ error: errorMsg })
-                  const strHandle = ctx.newString(jsonStr)
-                  deferred.resolve(strHandle)
-                  strHandle.dispose()
-                  ctx.runtime.executePendingJobs()
+                  // AX-09 — failures become typed recovery directives.
+                  settle(directiveFromError(e, path, method))
                 }
               )
 
               pendingPromises.push(hostPromise)
-
               return deferred.handle
             })
             ctx.setProp(audiusHandle, "request", requestFn)

--- a/src/tools/InspectEndpointTool.ts
+++ b/src/tools/InspectEndpointTool.ts
@@ -1,0 +1,115 @@
+/**
+ * inspect_endpoint tool (AX-06) — the focused "describe one endpoint" view.
+ *
+ * Where `search` answers "which endpoints exist?" with cheap compact rows,
+ * `inspect_endpoint` answers "how do I call exactly this one?" — parameters,
+ * response schema, the {data} envelope, an auth flag, and a runnable example.
+ */
+import { Effect } from "effect"
+import { SpecIndex, type EndpointMeta } from "../api/SpecIndex.js"
+import { CallToolResult, TextContent, ToolAnnotations, Tool } from "../mcp/McpSchema.js"
+
+export const inspectEndpointToolDefinition = Tool.make({
+  name: "inspect_endpoint",
+  title: "Inspect an Audius API endpoint",
+  description:
+    "Describe one Audius API endpoint in depth: its parameters, response schema, the " +
+    "{data} response envelope, whether it needs a user bearer token, and a runnable " +
+    "example call. Use after `search` to learn how to call a specific endpoint.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description: "Endpoint path, e.g. '/tracks/trending'"
+      },
+      method: {
+        type: "string",
+        description: "HTTP method (default GET)",
+        enum: ["GET", "POST", "PUT", "DELETE"]
+      }
+    },
+    required: ["path"]
+  },
+  annotations: ToolAnnotations.make({
+    title: "Inspect an Audius API endpoint",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false
+  })
+})
+
+/** Heuristic: user-scoped or mutating endpoints require a bearer token. */
+function requiresAuth(path: string, method: string): boolean {
+  return path.toLowerCase().startsWith("/me") || method !== "GET"
+}
+
+function buildExample(ep: EndpointMeta): string {
+  const requiredQuery = (ep.parameters ?? [])
+    .filter((p) => p.required && p.in === "query")
+    .map((p) => {
+      const v = p.type === "integer" || p.type === "number" ? "0" : "'…'"
+      return `${p.name}: ${v}`
+    })
+  const queryPart =
+    requiredQuery.length > 0 ? `, { query: { ${requiredQuery.join(", ")} } }` : ""
+  return `await audius.request('${ep.method}', '${ep.path}'${queryPart})`
+}
+
+export const handleInspectEndpoint = (
+  args: Record<string, unknown>
+): Effect.Effect<typeof CallToolResult.Type, never, SpecIndex> =>
+  Effect.gen(function* () {
+    const specIndex = yield* SpecIndex
+
+    const path = args["path"] as string | undefined
+    const method = ((args["method"] as string | undefined) ?? "GET").toUpperCase()
+
+    if (!path || typeof path !== "string") {
+      return CallToolResult.make({
+        content: [TextContent.make({
+          type: "text" as const,
+          text: "Error: 'path' is required, e.g. inspect_endpoint({ path: '/tracks/trending' })."
+        })],
+        isError: true
+      })
+    }
+
+    const ep = specIndex.getEndpoint(path, method)
+    if (!ep) {
+      return CallToolResult.make({
+        content: [TextContent.make({
+          type: "text" as const,
+          text: JSON.stringify({
+            error: `No endpoint ${method} ${path} in the Audius API spec.`,
+            nextActions: [
+              "Check the path and method.",
+              "Use search({ path: '<partial path>' }) to find the correct endpoint."
+            ]
+          }, null, 2)
+        })],
+        isError: true
+      })
+    }
+
+    const detail = {
+      method: ep.method,
+      path: ep.path,
+      operationId: ep.operationId,
+      summary: ep.summary,
+      requiresAuth: requiresAuth(ep.path, ep.method),
+      parameters: ep.parameters,
+      requestBody: ep.requestBody,
+      responseEnvelope: "List endpoints wrap their payload as { data: [ ... ] }.",
+      responseSchema: ep.responseSchema,
+      example: buildExample(ep)
+    }
+
+    return CallToolResult.make({
+      content: [TextContent.make({
+        type: "text" as const,
+        text: JSON.stringify(detail, null, 2)
+      })]
+    })
+  })

--- a/test/errors.test.mjs
+++ b/test/errors.test.mjs
@@ -1,0 +1,42 @@
+/**
+ * Behavioral tests for the typed error-directive model (AX-09 / AX-24).
+ */
+import test from "node:test"
+import assert from "node:assert/strict"
+import { buildErrorDirective, directiveFromError } from "../dist/api/Errors.js"
+
+test("buildErrorDirective maps 401 to AUTH_REQUIRED with a recovery directive", () => {
+  const d = buildErrorDirective({ status: 401, message: "nope", path: "/me", method: "GET" })
+  assert.equal(d.ok, false)
+  assert.equal(d.errorType, "AUTH_REQUIRED")
+  assert.equal(d.status, 401)
+  assert.ok(Array.isArray(d.nextActions) && d.nextActions.length > 0)
+  assert.ok(typeof d.prohibition === "string" && d.prohibition.length > 0)
+  assert.equal(d.context.path, "/me")
+})
+
+test("buildErrorDirective maps 429 to RATE_LIMITED", () => {
+  assert.equal(buildErrorDirective({ status: 429, message: "x" }).errorType, "RATE_LIMITED")
+})
+
+test("directiveFromError parses an Audius API error string and unwraps the body", () => {
+  const d = directiveFromError(
+    new Error('Audius API 404: {"code":404,"error":"invalid trackId"}'),
+    "/tracks/x",
+    "GET"
+  )
+  assert.equal(d.errorType, "NOT_FOUND")
+  assert.equal(d.status, 404)
+  assert.equal(d.message, "invalid trackId")
+  assert.equal(d.context.method, "GET")
+})
+
+test("directiveFromError classifies timeouts", () => {
+  const d = directiveFromError(new Error("request timed out"))
+  assert.equal(d.errorType, "TIMEOUT")
+})
+
+test("directiveFromError falls back to UPSTREAM_ERROR for unknown shapes", () => {
+  const d = directiveFromError(new Error("something odd"))
+  assert.equal(d.errorType, "UPSTREAM_ERROR")
+})

--- a/test/projection.test.mjs
+++ b/test/projection.test.mjs
@@ -1,0 +1,45 @@
+/**
+ * Behavioral tests for the default projection layer (AX-02 / AX-24).
+ */
+import test from "node:test"
+import assert from "node:assert/strict"
+import { project } from "../dist/api/Projection.js"
+
+test("project strips heavy keys by default", () => {
+  const r = project(
+    { data: [{ title: "x", artwork: { big: "..." }, stream: { url: "..." }, play_count: 5 }] },
+    {}
+  )
+  assert.equal(r.projected, true)
+  const item = r.value.data[0]
+  assert.equal(item.title, "x")
+  assert.equal(item.play_count, 5)
+  assert.equal(item.artwork, undefined)
+  assert.equal(item.stream, undefined)
+  assert.ok(typeof r.note === "string" && r.note.includes("raw"))
+})
+
+test("project leaves a clean payload untouched", () => {
+  const r = project({ data: [{ title: "x", play_count: 5 }] }, {})
+  assert.equal(r.projected, false)
+})
+
+test("project { raw: true } opts out entirely", () => {
+  const r = project({ data: [{ title: "x", artwork: {} }] }, { raw: true })
+  assert.equal(r.projected, false)
+  assert.ok("artwork" in r.value.data[0])
+})
+
+test("project { detail: 'full' } opts out entirely", () => {
+  const r = project({ data: [{ title: "x", stream: {} }] }, { detail: "full" })
+  assert.equal(r.projected, false)
+})
+
+test("project { fields } picks dot-paths element-wise across arrays", () => {
+  const r = project(
+    { data: [{ title: "a", x: 1 }, { title: "b", x: 2 }] },
+    { fields: ["data.title"] }
+  )
+  assert.equal(r.projected, true)
+  assert.deepEqual(r.value, { data: [{ title: "a" }, { title: "b" }] })
+})


### PR DESCRIPTION
## Release 2 of 3 — Agent Experience Alignment

Second of three stacked releases. **Targets `feat/ax-r1-context-safety`** — merge
[#29](https://github.com/glassBead-tc/audius-mcp-atris/pull/29) first, then this retargets to `main`.

**Theme: make it good.** Release 1 made the server *safe* (no payload can overflow
context). Release 2 makes it *efficient* and *self-correcting*.

### Included (7 improvements)
| ID | Change |
|----|--------|
| **AX-09** | `src/api/Errors.ts` — typed error-as-directive model. API failures resolve in the sandbox as `{ ok:false, errorType, status, message, context, nextActions, prohibition }`. Success responses unchanged. |
| **AX-02** | `src/api/Projection.ts` — default projection. `audius.request` responses have heavy media/wallet/CID keys stripped unless `{ raw:true }` / `{ detail:"full" }` / `{ fields:[...] }`. |
| **AX-04** | Projection self-announces — a `[projection] …` note in the execute output names what was dropped. |
| **AX-06** | New `inspect_endpoint` tool — one endpoint deep: parameters, response schema, the `{data}` envelope, `requiresAuth`, a runnable example. `SpecIndex.getEndpoint()` added. |
| **AX-19** | `audius://api/types` and `audius://sandbox/runtime` resources expose the generated type declarations and the sandbox capability manifest. |
| **AX-20** | Five workflow recipes registered as MCP prompts; `prompts` capability declared; `prompts/list` + `prompts/get` wired. |
| **AX-10** | Per-call 10 s host-fetch timeout + 64-call request budget per execute, surfaced as typed `TIMEOUT` / `REQUEST_BUDGET` errors. |

### Verification
- `pnpm build` — green.
- `pnpm test` — 15/15 pass (ResponseGuard, Projection, Errors).

### Notes
- Stacked on R1; Release 3 branches off this one.
- `INSTRUCTIONS` updated for `inspect_endpoint`, projection, and the new resources.
- `index.ts` now exposes the `TypeGenerator` layer so the handler can serve `audius://api/types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)