### PR TITLE
Release 3 — Harden (AX-13,14,15,16,18,21,22,23,25,03,12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased — Agent Experience Alignment
+## 3.0.0 (2026-05-21) — Agent Experience Alignment
 
 A multi-release program (specs in `specs/agent-experience-alignment/`) that brings the
 server into alignment with the 2026-05-21 agent-experience study. Restores the missing
@@ -40,6 +40,38 @@ server into alignment with the 2026-05-21 agent-experience study. Restores the m
   `audius-bpm-landscape`); the `prompts` capability is now declared.
 - **AX-10** — sandbox reliability: each `audius.request` is bounded by a 10 s host
   timeout, and an execute call may make at most 64 requests (`REQUEST_BUDGET`).
+
+### Release 3 — Harden
+- **AX-13** — `subgraph` is gated on `GRAPH_API_KEY`: when unconfigured it returns a
+  typed `SUBGRAPH_UNCONFIGURED` directive instead of hitting a keyless endpoint that
+  rejects every query. The dead keyless endpoint was removed.
+- **AX-14** — `play` is now an honest resolver: it returns `{ webUrl, deepLink, track }`
+  for the MCP client to open, and never shells out on the headless server or claims
+  playback it cannot observe.
+- **AX-15** — tool annotations corrected: `play` is genuinely `readOnlyHint: true`;
+  `execute` is `destructiveHint: true` (write methods perform real mutations).
+- **AX-16** — the transport no longer leaks raw internals: handler exceptions are
+  logged server-side with a ref id; the client receives a generic
+  `Internal server error (ref: …)`.
+- **AX-18** — metadata fidelity: `package.json` and `SERVER_INFO` versions reconciled
+  at `3.0.0`; the startup tool-list log corrected.
+- **AX-21** — generated type declarations now document the `{data}` envelope, the
+  error shape and projection, and mark `[auth]` endpoints.
+- **AX-22** — startup resilience: `SpecLoader` is network-first with a bundled
+  fallback (`specs/openapi-spec.yaml`, copied into the Docker image); an Audius docs
+  outage no longer prevents boot.
+- **AX-23** — `src/api/Cache.ts`: a 45 s per-instance TTL cache for hot idempotent
+  public reads, easing shared-API-key contention.
+- **AX-25** — observability: every tool call emits a structured log line
+  (`name`, `durationMs`, `chars`, `isError`).
+- **AX-12** — `audius.paginate(path, opts)` sandbox helper flattens a paginated
+  endpoint into one bounded `{ data: [...] }`.
+- **AX-03** — opt-in `options.fields` dot-path projection (delivered with AX-02).
+
+Deferred (tracked, not in this release): **AX-07** — a `code` escape hatch on `search`
+needs the QuickJS sandbox to run spec queries safely; **AX-11** — `audius.sleep` adds a
+host timer to the delicate promise-pump. The structured tools cover the need today;
+these remain power-features for a later release.
 
 ## 2.4.0 (2025-07-01)
 - Added stream-track and open-track-in-desktop tools for direct audio streaming.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN npm install -g pnpm@10.6.5
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod
 COPY --from=builder /app/dist ./dist
+# AX-22 — vendored OpenAPI spec, used as the offline fallback at startup.
+COPY specs ./specs
 EXPOSE 3000
 ENV PORT=3000
 ENV NODE_ENV=production

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audius-mcp-atris",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Audius MCP Server — Code Mode with Effect-TS",
   "main": "dist/index.js",
   "type": "module",

--- a/src/api/AudiusClient.ts
+++ b/src/api/AudiusClient.ts
@@ -9,6 +9,7 @@
  */
 import { Context, Effect, Layer } from "effect"
 import { AppConfig } from "../AppConfig.js"
+import { TtlCache } from "./Cache.js"
 
 const BASE_URL = "https://api.audius.co/v1"
 
@@ -39,6 +40,9 @@ export const AudiusClientLive: Layer.Layer<AudiusClient, never, AppConfig> = Lay
   Effect.gen(function* () {
     const config = yield* AppConfig
 
+    // AX-23 — per-instance TTL cache for hot, idempotent public reads.
+    const cache = new TtlCache(45_000)
+
     const request = (
       method: string,
       path: string,
@@ -66,6 +70,17 @@ export const AudiusClientLive: Layer.Layer<AudiusClient, never, AppConfig> = Lay
             if (value !== undefined) {
               url.searchParams.set(key, String(value))
             }
+          }
+        }
+
+        // AX-23 — serve hot, idempotent reads from the per-instance cache.
+        const cacheable =
+          method.toUpperCase() === "GET" && !options?.body && !authContext?.bearerToken
+        const cacheKey = url.toString()
+        if (cacheable) {
+          const hit = cache.get(cacheKey)
+          if (hit !== undefined) {
+            return hit
           }
         }
 
@@ -108,6 +123,10 @@ export const AudiusClientLive: Layer.Layer<AudiusClient, never, AppConfig> = Lay
           try: () => response.json() as Promise<unknown>,
           catch: (e) => new Error(`Failed to parse JSON response: ${e}`)
         })
+
+        if (cacheable) {
+          cache.set(cacheKey, json)
+        }
 
         return json
       })

--- a/src/api/Cache.ts
+++ b/src/api/Cache.ts
@@ -1,0 +1,43 @@
+/**
+ * Cache.ts — a tiny per-instance TTL cache for hot, idempotent reads (AX-23).
+ *
+ * Atris authenticates public reads with one shared API key, so a burst from
+ * one agent can rate-limit another. Caching slow-moving GETs (trending, search)
+ * for a short TTL absorbs duplicate upstream load — and is a context-economy
+ * win too: a cache hit serves the same bytes with zero upstream calls.
+ *
+ * Per-instance and best-effort by design — Cloud Run instances are ephemeral,
+ * so only data that tolerates a few seconds of staleness should be cached.
+ */
+export interface CacheEntry {
+  value: unknown
+  expiresAt: number
+}
+
+export class TtlCache {
+  private readonly store = new Map<string, CacheEntry>()
+
+  constructor(
+    private readonly ttlMs: number,
+    private readonly maxEntries: number = 200
+  ) {}
+
+  get(key: string): unknown | undefined {
+    const entry = this.store.get(key)
+    if (!entry) return undefined
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key)
+      return undefined
+    }
+    return entry.value
+  }
+
+  set(key: string, value: unknown): void {
+    // Simple bound: evict the oldest insertion when full.
+    if (this.store.size >= this.maxEntries) {
+      const oldest = this.store.keys().next().value
+      if (oldest !== undefined) this.store.delete(oldest)
+    }
+    this.store.set(key, { value, expiresAt: Date.now() + this.ttlMs })
+  }
+}

--- a/src/api/SpecLoader.ts
+++ b/src/api/SpecLoader.ts
@@ -7,6 +7,8 @@
  * - Exposes as Effect service
  */
 import { Context, Effect, Layer } from "effect"
+import { readFile } from "node:fs/promises"
+import { fileURLToPath } from "node:url"
 import YAML from "yaml"
 
 const SPEC_URL = "https://api.audius.co/v1/swagger.yaml"
@@ -96,6 +98,45 @@ function followRef(ref: string, root: unknown): unknown {
 }
 
 // ---------------------------------------------------------------------------
+// Spec text loading — network first, vendored fallback second (AX-22)
+// ---------------------------------------------------------------------------
+
+interface LoadedSpec {
+  readonly text: string
+  readonly source: "network" | "bundled"
+}
+
+async function fetchSpecText(): Promise<string> {
+  const response = await fetch(SPEC_URL)
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`)
+  }
+  return response.text()
+}
+
+async function bundledSpecText(): Promise<string> {
+  // dist/api/SpecLoader.js -> ../../specs/openapi-spec.yaml (repo / image root).
+  const url = new URL("../../specs/openapi-spec.yaml", import.meta.url)
+  return readFile(fileURLToPath(url), "utf-8")
+}
+
+/** Load the raw spec text: the live Audius spec first, the vendored copy second. */
+async function loadSpecText(): Promise<LoadedSpec> {
+  try {
+    return { text: await fetchSpecText(), source: "network" }
+  } catch (netErr) {
+    try {
+      return { text: await bundledSpecText(), source: "bundled" }
+    } catch {
+      throw new Error(
+        `Failed to load the Audius API spec from the network (${netErr}) ` +
+        `and no usable bundled fallback at specs/openapi-spec.yaml`
+      )
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
 
@@ -107,26 +148,20 @@ export class SpecLoader extends Context.Tag("SpecLoader")<
 export const SpecLoaderLive: Layer.Layer<SpecLoader, Error> = Layer.effect(
   SpecLoader,
   Effect.gen(function* () {
-    const response = yield* Effect.tryPromise({
-      try: () => fetch(SPEC_URL),
-      catch: (e) => new Error(`Failed to fetch spec: ${e}`)
-    })
-    if (!response.ok) {
-      const errText = yield* Effect.tryPromise({
-        try: () => response.text(),
-        catch: () => new Error("Failed to read error body")
-      })
-      return yield* Effect.fail(new Error(`Failed to fetch spec: HTTP ${response.status} — ${errText.slice(0, 200)}`))
-    }
-    const text = yield* Effect.tryPromise({
-      try: () => response.text(),
-      catch: (e) => new Error(`Failed to read spec body: ${e}`)
+    // AX-22 — network-first, bundled-fallback. An Audius docs outage degrades
+    // Atris to a slightly stale spec instead of failing to boot.
+    const loaded = yield* Effect.tryPromise({
+      try: loadSpecText,
+      catch: (e) => new Error(String(e))
     })
 
-    const raw = YAML.parse(text) as Record<string, unknown>
+    const raw = YAML.parse(loaded.text) as Record<string, unknown>
     const resolved = resolveRefs(raw, raw, new Set()) as OpenApiSpec
 
-    yield* Effect.logInfo(`Loaded Audius API spec: ${Object.keys(resolved.paths ?? {}).length} paths`)
+    yield* Effect.logInfo(
+      `Loaded Audius API spec from ${loaded.source}: ` +
+      `${Object.keys(resolved.paths ?? {}).length} paths`
+    )
 
     return { spec: resolved }
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ const program = Effect.gen(function* () {
 
   yield* Effect.logInfo(`Audius MCP Server (Code Mode) listening on port ${config.port}`)
   yield* Effect.logInfo("Transport: Streamable HTTP at POST /mcp")
-  yield* Effect.logInfo("Tools: search, execute, play, subgraph")
+  yield* Effect.logInfo("Tools: search, inspect_endpoint, execute, play, subgraph")
 
   // Keep running until interrupted (SIGINT/SIGTERM trigger Effect interruption)
   yield* Effect.never

--- a/src/mcp/McpServer.ts
+++ b/src/mcp/McpServer.ts
@@ -32,7 +32,7 @@ import { listPrompts, getPrompt, buildPromptResult } from "./Prompts.js"
 
 const SERVER_INFO = {
   name: "audius-mcp",
-  version: "2.0.0",
+  version: "3.0.0",
   description: "Audius Music Platform MCP Server (Code Mode)"
 }
 
@@ -297,6 +297,7 @@ function handleToolCall(
     const config = yield* AppConfig
     const name = payload["name"] as string
     const args = (payload["arguments"] as Record<string, unknown>) ?? {}
+    const startTime = Date.now()
 
     let result: typeof CallToolResult.Type
     switch (name) {
@@ -321,7 +322,15 @@ function handleToolCall(
 
     // AX-01a — every tool result passes through the output cap before the wire,
     // so no payload can ever exceed the agent's context budget.
-    return makeResponse(id, capResult(result, config.responseTokenBudget))
+    const capped = capResult(result, config.responseTokenBudget)
+
+    // AX-25 — per-call structured log so agent experience is observable.
+    yield* Effect.logInfo(
+      `[tool] name=${name} durationMs=${Date.now() - startTime} ` +
+      `chars=${JSON.stringify(capped).length} isError=${capped.isError ?? false}`
+    )
+
+    return makeResponse(id, capped)
   })
 }
 

--- a/src/mcp/McpServerTransport.ts
+++ b/src/mcp/McpServerTransport.ts
@@ -157,6 +157,10 @@ export const startServer = (
             try {
               result = await config.handler(msg, bearerToken)
             } catch (cause) {
+              // AX-16 — log the full cause server-side; return a generic
+              // message with a correlation ref so internals never leak.
+              const ref = Math.random().toString(36).slice(2, 10)
+              console.error(`[mcp] internal error ref=${ref}:`, cause)
               result = {
                 _tag: "Exit",
                 requestId: internal["id"] ?? "",
@@ -166,7 +170,7 @@ export const startServer = (
                     _tag: "Fail",
                     error: {
                       code: -32603,
-                      message: `Internal error: ${cause}`
+                      message: `Internal server error (ref: ${ref})`
                     }
                   }
                 }

--- a/src/sandbox/Sandbox.ts
+++ b/src/sandbox/Sandbox.ts
@@ -215,6 +215,27 @@ export const SandboxLive: Layer.Layer<Sandbox, Error, AudiusClient | TypeGenerat
                   .then(function(jsonStr) { return JSON.parse(jsonStr); });
               };
 
+              // AX-12 — audius.paginate(path, opts): walk a paginated endpoint
+              // and return a single flattened { data: [...] }, bounded by opts.max.
+              audius.paginate = async function(path, opts) {
+                opts = opts || {};
+                var pageSize = opts.pageSize || 50;
+                var max = opts.max || 200;
+                var out = [];
+                var offset = 0;
+                while (out.length < max) {
+                  var q = Object.assign({}, opts.query || {}, { limit: pageSize, offset: offset });
+                  var res = await audius.request('GET', path, { query: q, raw: opts.raw });
+                  if (res && res.ok === false) return res;
+                  var data = (res && res.data) || [];
+                  if (data.length === 0) break;
+                  out = out.concat(data);
+                  if (data.length < pageSize) break;
+                  offset += pageSize;
+                }
+                return { data: out.slice(0, max) };
+              };
+
               var __result__ = undefined;
               var __execError__ = undefined;
 

--- a/src/sandbox/TypeGenerator.ts
+++ b/src/sandbox/TypeGenerator.ts
@@ -33,6 +33,11 @@ export const TypeGeneratorLive: Layer.Layer<TypeGenerator, never, SpecLoader> = 
 function generateDeclarations(spec: OpenApiSpec): string {
   const lines: string[] = [
     "// Audius API type declarations (auto-generated from OpenAPI spec)",
+    "//",
+    "// Response envelope: list endpoints wrap their payload as { data: [ ... ] }.",
+    "// Auth: endpoints marked [auth] require a user bearer token (e.g. /me*).",
+    "// Errors: a failed audius.request resolves { ok:false, errorType, nextActions, ... }.",
+    "// Projection: responses are trimmed by default — pass { raw: true } for the full payload.",
     "",
     "interface RequestOptions {",
     "  query?: Record<string, string | number | boolean>;",
@@ -73,8 +78,9 @@ function generateDeclarations(spec: OpenApiSpec): string {
         .filter((p) => p.required)
         .map((p) => `${p.name}: ${schemaToTsType(p.schema)}`)
 
+      const authMark = path.toLowerCase().startsWith("/me") ? "[auth] " : ""
       lines.push(
-        `  // ${method.toUpperCase()} ${path}${summary ? ` — ${truncate(summary, 80)}` : ""}`
+        `  // ${authMark}${method.toUpperCase()} ${path}${summary ? ` — ${truncate(summary, 80)}` : ""}`
       )
       if (paramList.length > 0) {
         lines.push(`  //   Required params: ${paramList.join(", ")}`)

--- a/src/tools/ExecuteTool.ts
+++ b/src/tools/ExecuteTool.ts
@@ -38,7 +38,9 @@ export const executeToolDefinition = Tool.make({
   annotations: ToolAnnotations.make({
     title: "Execute Audius API Code",
     readOnlyHint: false,
-    destructiveHint: false,
+    // Write methods (POST/PUT/DELETE) perform real mutations when a user
+    // bearer token is supplied — declare the tool as potentially destructive.
+    destructiveHint: true,
     idempotentHint: false,
     openWorldHint: true
   })

--- a/src/tools/PlayTool.ts
+++ b/src/tools/PlayTool.ts
@@ -1,18 +1,14 @@
 /**
- * Play tool — open a track in the Audius desktop app or browser.
+ * Play tool — resolve a track to its Audius URLs (AX-14).
  *
- * Flow:
- * 1. Resolve the track (by ID or search query) via the Audius API
- * 2. Attempt to open in the Audius desktop app via audius:// protocol
- * 3. Fall back to opening in the user's default browser
- *
- * This tool runs system commands (open/xdg-open/start) so it only
- * works when the MCP server is running on the user's local machine.
+ * Atris is deployed on Cloud Run: a headless container, not the user's
+ * device. A server-side process cannot open media on a remote user's
+ * machine, so this tool does NOT shell out and does NOT claim playback.
+ * It resolves the track and hands back openable URLs — the web link and
+ * the `audius://` desktop deep link — and whoever sits beside the user
+ * (the MCP client) performs the actual open.
  */
 import { Effect } from "effect"
-import { exec } from "node:child_process"
-import { access, constants } from "node:fs/promises"
-import { platform } from "node:os"
 import { AudiusClient } from "../api/AudiusClient.js"
 import { CallToolResult, TextContent, ToolAnnotations, Tool } from "../mcp/McpSchema.js"
 
@@ -22,125 +18,34 @@ import { CallToolResult, TextContent, ToolAnnotations, Tool } from "../mcp/McpSc
 
 export const playToolDefinition = Tool.make({
   name: "play",
-  title: "Play Track on Audius",
+  title: "Resolve a Track on Audius",
   description:
-    "Play a track on the user's machine by opening it in the Audius desktop app " +
-    "(if installed) or in their default browser. Provide either a track ID or a " +
-    "search query to find and play a track. The server must be running locally.",
+    "Resolve a track to its Audius URLs — a web link (audius.co/...) and an " +
+    "audius:// desktop deep link. Provide either a track ID or a search query. " +
+    "Returns the URLs for the MCP client to open; it does not play audio itself.",
   inputSchema: {
     type: "object",
     properties: {
       trackId: {
         type: "string",
-        description: "Audius track ID to play (e.g., 'D7KyD')"
+        description: "Audius track ID to resolve (e.g., 'D7KyD')"
       },
       query: {
         type: "string",
-        description: "Search query to find a track (uses first result). " +
+        description:
+          "Search query to find a track (uses the first result). " +
           "Use this when you know the track name but not the ID."
-      },
-      preferBrowser: {
-        type: "boolean",
-        description: "Force opening in browser even if desktop app is available (default: false)"
       }
     }
   },
   annotations: ToolAnnotations.make({
-    title: "Play Track on Audius",
+    title: "Resolve a Track on Audius",
     readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true
   })
 })
-
-// ---------------------------------------------------------------------------
-// Platform utilities
-// ---------------------------------------------------------------------------
-
-/** Known paths where the Audius desktop app might be installed */
-const DESKTOP_APP_PATHS: Record<string, string[]> = {
-  darwin: [
-    "/Applications/Audius.app",
-    `${process.env["HOME"]}/Applications/Audius.app`
-  ],
-  win32: [
-    `${process.env["LOCALAPPDATA"]}\\Programs\\Audius\\Audius.exe`,
-    `${process.env["PROGRAMFILES"]}\\Audius\\Audius.exe`
-  ],
-  linux: [
-    "/usr/bin/audius",
-    "/usr/local/bin/audius",
-    `${process.env["HOME"]}/.local/bin/audius`,
-    // Snap/Flatpak
-    "/snap/bin/audius",
-    `${process.env["HOME"]}/.local/share/flatpak/exports/bin/com.audius.Audius`
-  ]
-}
-
-async function findDesktopApp(): Promise<string | null> {
-  const os = platform()
-  const paths = DESKTOP_APP_PATHS[os] ?? []
-
-  for (const p of paths) {
-    if (!p) continue
-    try {
-      await access(p, constants.F_OK)
-      return p
-    } catch {
-      // Not found at this path, try next
-    }
-  }
-  return null
-}
-
-function openUrl(url: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const os = platform()
-    let cmd: string
-
-    switch (os) {
-      case "darwin":
-        cmd = `open "${url}"`
-        break
-      case "win32":
-        cmd = `start "" "${url}"`
-        break
-      default: // linux and others
-        cmd = `xdg-open "${url}"`
-        break
-    }
-
-    exec(cmd, (error) => {
-      if (error) reject(error)
-      else resolve()
-    })
-  })
-}
-
-function openWithApp(appPath: string, url: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const os = platform()
-    let cmd: string
-
-    switch (os) {
-      case "darwin":
-        cmd = `open -a "${appPath}" "${url}"`
-        break
-      case "win32":
-        cmd = `"${appPath}" "${url}"`
-        break
-      default:
-        cmd = `"${appPath}" "${url}"`
-        break
-    }
-
-    exec(cmd, (error) => {
-      if (error) reject(error)
-      else resolve()
-    })
-  })
-}
 
 // ---------------------------------------------------------------------------
 // Handler
@@ -155,47 +60,41 @@ export const handlePlay = (
     const authContext = bearerToken ? { bearerToken } : undefined
     const trackId = args["trackId"] as string | undefined
     const query = args["query"] as string | undefined
-    const preferBrowser = args["preferBrowser"] as boolean | undefined
 
     if (!trackId && !query) {
       return CallToolResult.make({
         content: [TextContent.make({
           type: "text" as const,
-          text: "Error: Provide either 'trackId' or 'query' to find a track to play."
+          text: "Error: provide either 'trackId' or 'query' to resolve a track."
         })],
         isError: true
       })
     }
 
-    // Step 1: Resolve track info
+    // Resolve the track via the Audius API.
     let track: Record<string, unknown> | undefined
 
     if (trackId) {
-      // Fetch track by ID
       const result = yield* Effect.catchAll(
         audiusClient.request("GET", `/tracks/${trackId}`, undefined, authContext),
         (error) => Effect.succeed({ error: error.message } as unknown)
       )
-
       const data = result as Record<string, unknown>
       if (data["error"]) {
         return CallToolResult.make({
           content: [TextContent.make({
             type: "text" as const,
-            text: `Error fetching track ${trackId}: ${data["error"]}`
+            text: `Error resolving track ${trackId}: ${data["error"]}`
           })],
           isError: true
         })
       }
-
       track = (data["data"] as Record<string, unknown>) ?? data
     } else if (query) {
-      // Search for track
       const result = yield* Effect.catchAll(
         audiusClient.request("GET", "/tracks/search", { query: { query } }, authContext),
         (error) => Effect.succeed({ error: error.message } as unknown)
       )
-
       const data = result as Record<string, unknown>
       if (data["error"]) {
         return CallToolResult.make({
@@ -206,7 +105,6 @@ export const handlePlay = (
           isError: true
         })
       }
-
       const tracks = (data["data"] as unknown[]) ?? []
       if (tracks.length === 0) {
         return CallToolResult.make({
@@ -217,7 +115,6 @@ export const handlePlay = (
           isError: true
         })
       }
-
       track = tracks[0] as Record<string, unknown>
     }
 
@@ -225,74 +122,34 @@ export const handlePlay = (
       return CallToolResult.make({
         content: [TextContent.make({
           type: "text" as const,
-          text: "Error: Could not resolve track."
+          text: "Error: could not resolve a track."
         })],
         isError: true
       })
     }
 
-    // Step 2: Build URLs
+    // Build the openable URLs.
     const permalink = track["permalink"] as string | undefined
-    const title = track["title"] as string ?? "Unknown Track"
-    const artist = (track["user"] as Record<string, unknown>)?.["name"] as string ?? "Unknown Artist"
+    const id = (track["id"] as string | undefined) ?? trackId ?? ""
+    const title = (track["title"] as string | undefined) ?? "Unknown Track"
+    const artist =
+      ((track["user"] as Record<string, unknown>)?.["name"] as string | undefined) ??
+      "Unknown Artist"
 
-    // Build web URL from permalink or fall back to track ID
     const webUrl = permalink
       ? (permalink.startsWith("http") ? permalink : `https://audius.co${permalink}`)
-      : `https://audius.co/tracks/${trackId ?? ""}`
+      : `https://audius.co/tracks/${id}`
+    const deepLink = `audius://${webUrl.replace(/^https?:\/\//, "")}`
 
-    // Step 3: Try to open in desktop app, fall back to browser
-    let openedWith = "browser"
-
-    if (!preferBrowser) {
-      const appPath = yield* Effect.tryPromise({
-        try: () => findDesktopApp(),
-        catch: () => new Error("Failed to search for desktop app")
-      }).pipe(Effect.catchAll(() => Effect.succeed(null)))
-
-      if (appPath) {
-        // Try opening with the desktop app
-        const openResult = yield* Effect.tryPromise({
-          try: () => openWithApp(appPath, webUrl),
-          catch: (e) => new Error(`Failed to open desktop app: ${e}`)
-        }).pipe(Effect.catchAll(() => Effect.succeed("failed" as const)))
-
-        if (openResult !== "failed") {
-          openedWith = "desktop app"
-        }
-      }
-    }
-
-    // Fall back to browser if desktop didn't work
-    if (openedWith === "browser") {
-      const openResult = yield* Effect.tryPromise({
-        try: () => openUrl(webUrl),
-        catch: (e) => new Error(`Failed to open browser: ${e}`)
-      }).pipe(Effect.catchAll((error) => Effect.succeed(error)))
-
-      if (openResult instanceof Error) {
-        return CallToolResult.make({
-          content: [TextContent.make({
-            type: "text" as const,
-            text: `Found "${title}" by ${artist} but failed to open it: ${openResult.message}\n\nURL: ${webUrl}`
-          })],
-          isError: true
-        })
-      }
-    }
-
-    // Step 4: Return success
     return CallToolResult.make({
       content: [TextContent.make({
         type: "text" as const,
         text: JSON.stringify({
-          status: "playing",
-          openedWith,
-          track: {
-            title,
-            artist,
-            url: webUrl
-          }
+          status: "resolved",
+          track: { id, title, artist },
+          webUrl,
+          deepLink,
+          note: "Open webUrl (or deepLink for the desktop app) on the user's device."
         }, null, 2)
       })]
     })

--- a/src/tools/SubgraphTool.ts
+++ b/src/tools/SubgraphTool.ts
@@ -9,6 +9,7 @@
  */
 import { Effect } from "effect"
 import { AppConfig } from "../AppConfig.js"
+import { buildErrorDirective } from "../api/Errors.js"
 import { CallToolResult, TextContent, ToolAnnotations, Tool } from "../mcp/McpSchema.js"
 
 // ---------------------------------------------------------------------------
@@ -17,10 +18,7 @@ import { CallToolResult, TextContent, ToolAnnotations, Tool } from "../mcp/McpSc
 
 const SUBGRAPH_ID = "F8TjrYuTLohz64J8uuDke9htSR1aY9TGCuEjJVVjUJaD"
 
-/** Public endpoint (rate-limited, no API key needed) */
-const PUBLIC_ENDPOINT = `https://gateway.thegraph.com/api/subgraphs/id/${SUBGRAPH_ID}`
-
-/** Authenticated endpoint template (higher rate limits) */
+/** The Graph gateway endpoint — the API key is embedded in the path. */
 const authedEndpoint = (apiKey: string) =>
   `https://gateway.thegraph.com/api/${apiKey}/subgraphs/id/${SUBGRAPH_ID}`
 
@@ -89,8 +87,23 @@ export const handleSubgraph = (
       })
     }
 
-    // Use authenticated endpoint if a Graph API key is available
-    const endpoint = config.graphApiKey ? authedEndpoint(config.graphApiKey) : PUBLIC_ENDPOINT
+    // AX-13 — subgraph requires a Graph API key. Fail honestly when it is
+    // unconfigured instead of hitting a keyless endpoint that rejects everything.
+    if (!config.graphApiKey) {
+      return CallToolResult.make({
+        content: [TextContent.make({
+          type: "text" as const,
+          text: JSON.stringify(buildErrorDirective({
+            status: 0,
+            errorType: "SUBGRAPH_UNCONFIGURED",
+            message:
+              "The subgraph tool is not configured on this deployment — GRAPH_API_KEY is not set."
+          }), null, 2)
+        })],
+        isError: true
+      })
+    }
+    const endpoint = authedEndpoint(config.graphApiKey)
 
     const response = yield* Effect.tryPromise({
       try: () =>

--- a/test/cache.test.mjs
+++ b/test/cache.test.mjs
@@ -1,0 +1,33 @@
+/**
+ * Behavioral tests for the hot-read TTL cache (AX-23 / AX-24).
+ */
+import test from "node:test"
+import assert from "node:assert/strict"
+import { TtlCache } from "../dist/api/Cache.js"
+
+test("TtlCache stores and returns a value within the TTL", () => {
+  const c = new TtlCache(1000)
+  c.set("k", { v: 1 })
+  assert.deepEqual(c.get("k"), { v: 1 })
+})
+
+test("TtlCache misses for unknown keys", () => {
+  const c = new TtlCache(1000)
+  assert.equal(c.get("nope"), undefined)
+})
+
+test("TtlCache expires entries past the TTL", async () => {
+  const c = new TtlCache(10)
+  c.set("k", 1)
+  await new Promise((r) => setTimeout(r, 30))
+  assert.equal(c.get("k"), undefined)
+})
+
+test("TtlCache evicts the oldest entry when over capacity", () => {
+  const c = new TtlCache(10_000, 2)
+  c.set("a", 1)
+  c.set("b", 2)
+  c.set("c", 3)
+  assert.equal(c.get("a"), undefined, "oldest entry should be evicted")
+  assert.equal(c.get("c"), 3)
+})


### PR DESCRIPTION
## Release 3 of 3 — Agent Experience Alignment

Final release. **Targets `feat/ax-r2-make-it-good`** — merge
[#29](https://github.com/glassBead-tc/audius-mcp-atris/pull/29) and
[#30](https://github.com/glassBead-tc/audius-mcp-atris/pull/30) first, then this retargets to `main`.

**Theme: harden.** Releases 1–2 made the server safe and good; Release 3 makes it
truthful, resilient and operable.

### Included (11 improvements)
| ID | Change |
|----|--------|
| **AX-13** | `subgraph` gated on `GRAPH_API_KEY` — typed `SUBGRAPH_UNCONFIGURED` directive when unset; dead keyless endpoint removed. |
| **AX-14** | `play` reframed as an honest resolver — returns `{ webUrl, deepLink, track }`; no server-side `exec`, no false `"playing"` status. |
| **AX-15** | Annotations corrected — `play` `readOnlyHint:true`, `execute` `destructiveHint:true`. |
| **AX-16** | Transport no longer leaks raw internals — generic error + correlation ref; full cause logged server-side. |
| **AX-18** | Metadata fidelity — `package.json` + `SERVER_INFO` reconciled at `3.0.0`; startup tool-list log corrected. |
| **AX-21** | Generated type declarations document the `{data}` envelope, error shape, projection, and mark `[auth]` endpoints. |
| **AX-22** | `SpecLoader` is network-first with a bundled fallback (`specs/openapi-spec.yaml`, copied into the Docker image). |
| **AX-23** | `src/api/Cache.ts` — 45 s per-instance TTL cache for hot idempotent reads. |
| **AX-25** | Per-call structured logging (`name`, `durationMs`, `chars`, `isError`). |
| **AX-12** | `audius.paginate(path, opts)` sandbox helper. |
| **AX-03** | Opt-in `options.fields` projection (shipped with AX-02 in R2). |

### Deferred (honest scope call — tracked, not shipped)
- **AX-07** — a `code` escape hatch on `search` needs the QuickJS sandbox to run spec queries safely (running it via `new Function` would be an unsandboxed eval). The structured `search` + `inspect_endpoint` cover the need today.
- **AX-11** — `audius.sleep` adds a host timer to the delicate promise-pump bridge; deferred to avoid risking sandbox stability for a low-impact convenience.

### Verification
- `pnpm build` — green.
- `pnpm test` — 19/19 pass (ResponseGuard, Projection, Errors, Cache).
- Server boot verified: spec loads, 5 tools and 5 prompts listed, `/health` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)